### PR TITLE
Fix problem where `fab code_init` would incorrectly bomb out on python version assert

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -8,7 +8,7 @@ References:
 '''
 
 import platform
-assert (2,6) <= platform.python_version_tuple() < (3,0)
+assert ('2','6') <= platform.python_version_tuple() < ('3','0')
 
 import os
 import datetime

--- a/setup/code_init.bash
+++ b/setup/code_init.bash
@@ -9,7 +9,7 @@ source "$SITE_CODE_DIR/setup/bashutils.bash"
 
 ## Check Python version ##
 
-if [[ $(python -c "import platform; print (2,6) <= platform.python_version_tuple() < (3,0)") != "True" ]]
+if [[ $(python -c "import platform; print ('2','6') <= platform.python_version_tuple() < ('3','0')") != "True" ]]
 then
     critical "Need at least Python 2.6"
 fi


### PR DESCRIPTION
platform.python_version_tuple returns a tuple of strings, so the tuple of integers was causing problems
