### PR TITLE
removing empty double quotes from sed commands

### DIFF
--- a/setup/code_init.bash
+++ b/setup/code_init.bash
@@ -42,7 +42,7 @@ cd "$SITE_CODE_DIR/$APP_NAME"
 
 info "Generating secret key and updating config file"
 SECRET_KEY=`python -c 'import random; print "".join([random.choice("abcdefghijklmnopqrstuvwxyz0123456789@#$%^*(-_=+)") for i in range(50)])'`
-sed -i "" -e "s/{SECRET_KEY}/$SECRET_KEY/g" -e "s/{SITE_NAME}/$SITE_NAME/g" "config.py" || critical "Could not fill $APP_NAME/config.py"
+sed -i -e "s/{SECRET_KEY}/$SECRET_KEY/g" -e "s/{SITE_NAME}/$SITE_NAME/g" "config.py" || critical "Could not fill $APP_NAME/config.py"
 
 cd "$SITE_CODE_DIR/setup"
 
@@ -52,16 +52,16 @@ info "Generating WSGI file"
 if [[ ! -f "$APP_NAME.wsgi" ]]
 then
     git mv run.wsgi "$APP_NAME.wsgi"
-    sed -i "" -e "s/{SITE_NAME}/$SITE_NAME/g" -e "s/{APP_NAME}/$APP_NAME/g" -e "s/{HOME}/$LINUX_HOME_ESCAPED/g" "$APP_NAME.wsgi" || critical "Could not fill $APP_NAME.wsgi"
+    sed -i -e "s/{SITE_NAME}/$SITE_NAME/g" -e "s/{APP_NAME}/$APP_NAME/g" -e "s/{HOME}/$LINUX_HOME_ESCAPED/g" "$APP_NAME.wsgi" || critical "Could not fill $APP_NAME.wsgi"
 fi
 
 info "Updating fabfile"
 cd "$SITE_CODE_DIR"
-sed -i "" -e "s/{SITE_NAME}/$SITE_NAME/g"  "fabfile.py" || critical "Could not fill fabfile.py"
+sed -i -e "s/{SITE_NAME}/$SITE_NAME/g"  "fabfile.py" || critical "Could not fill fabfile.py"
 
 info "Updating Apache site configuration"
 cd "$SITE_CODE_DIR/setup"
-sed -i "" -e "s/{SITE_NAME}/$SITE_NAME/g" -e "s/{HOME}/$LINUX_HOME_ESCAPED/g" -e "s/{APP_NAME}/$APP_NAME/g" -e "s/{ADMIN_EMAIL}/$ADMIN_EMAIL/g" -e "s/{USER}/$USER/g" apache_site_entry || critical "Could not fill apache config file"
+sed -i -e "s/{SITE_NAME}/$SITE_NAME/g" -e "s/{HOME}/$LINUX_HOME_ESCAPED/g" -e "s/{APP_NAME}/$APP_NAME/g" -e "s/{ADMIN_EMAIL}/$ADMIN_EMAIL/g" -e "s/{USER}/$USER/g" apache_site_entry || critical "Could not fill apache config file"
 
 info "Removing LICENSE and README files"
 git rm $SITE_CODE_DIR/LICENSE.txt


### PR DESCRIPTION
If the double quotes are not necessary (it worked without them on ubuntu, for me), then I'm sending this pull request to help you.
If they are necessary, please let me know.
Thanks.
